### PR TITLE
Remove `grunt-replace` nodejs dependency

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -19,7 +19,6 @@
     "grunt-jscoverage": "0.1.1",
     "grunt-json-minify": "^1.1.0",
     "grunt-mocha": "^1.0.0",
-    "grunt-replace": "^1.0.0",
     "grunt-spritesmith": "^6.8.0",
     "grunt-svgmin": "^6.0.0",
     "grunt-text-replace": "0.3.11",


### PR DESCRIPTION
This was introduced since first commit to `web-apps`:
https://github.com/ONLYOFFICE/web-apps/commit/741b10515de246f1e426032b5e09202a4791591f
Accroding to https://www.npmjs.com/package/grunt-replace
it create grunt task `grunt-replace` but it's never used.
Also this depends on [`"lodash": "^4.11.0"`](https://github.com/outaTiME/grunt-replace/blob/master/package.json#L21) and blocking
security updates of `lodash` (current 4.17.15)

For some replacement task [`grunt-text-replace`](https://www.npmjs.com/package/grunt-text-replace) is used and it got no non-actual dependencies