### PR TITLE
Remove unneded dependency `grunt-jscoverage`

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -16,7 +16,6 @@
     "grunt-contrib-requirejs": "^1.0.0",
     "grunt-contrib-uglify": "^4.0.1",
     "grunt-inline": "0.3.4",
-    "grunt-jscoverage": "0.1.1",
     "grunt-json-minify": "^1.1.0",
     "grunt-mocha": "^1.0.0",
     "grunt-spritesmith": "^6.8.0",


### PR DESCRIPTION
This was added in first commit:
https://github.com/ONLYOFFICE/web-apps/commit/741b10515de246f1e426032b5e09202a4791591f
Task was not initialized and never used, no source of
`jscoverage:` config found, `grunt jscoverage` failing with error