### PR TITLE
Modifications to get DocumentServer@web-apps working under FreeBSD

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -99,7 +99,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-htmlmin');
     grunt.loadNpmTasks('grunt-json-minify');
     grunt.loadNpmTasks('grunt-text-replace');
-    grunt.loadNpmTasks('grunt-mocha');
     grunt.loadNpmTasks('grunt-inline');
     grunt.loadNpmTasks('grunt-svgmin');
 
@@ -178,17 +177,6 @@ module.exports = function(grunt) {
     }
 
     grunt.initConfig({
-        mocha: {
-            test: {
-                options: {
-                    reporter: 'Spec'
-                },
-                src: [
-                    '../test/common/index.html'
-                ]
-            }
-        },
-
         jshint: {
             options: {
                 curly: true,

--- a/build/package.json
+++ b/build/package.json
@@ -17,7 +17,6 @@
     "grunt-contrib-uglify": "^4.0.1",
     "grunt-inline": "0.3.4",
     "grunt-json-minify": "^1.1.0",
-    "grunt-mocha": "^1.0.0",
     "grunt-spritesmith": "^6.8.0",
     "grunt-svgmin": "^6.0.0",
     "grunt-text-replace": "0.3.11",


### PR DESCRIPTION
Remove the use of grunt-mocha package (it seems is it not used in production).
This package needs phantomjs which seems to be an unmaintained package. Since it is no more available under FreeBSD I removed this line. There is no consequences on the OnlyOffice DocumentServer code.