### PR TITLE
Fix building web-apps by require sdkjs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,4 +12,7 @@ jobs:
       - name: Build using grunt
         run: |
           npm install --prefix build
+          cd ..
+          git clone --branch=develop --depth=1 https://github.com/ONLYOFFICE/sdkjs.git
+          cd web-apps
           grunt --level=ADVANCED --base build --gruntfile build/Gruntfile.js


### PR DESCRIPTION
Since this commit on develop
https://github.com/ONLYOFFICE/web-apps/commit/3636bf78c4bd2e05f180b66b82000f4ceac2c9e4
web-apps require file from `sdkjs` named
```
'../../../../sdkjs/common/device_scale.js'
```
So cloning of sdkjs is bring back
Currently it will clone `sdkjs#develop` for any branches,
since implement cloning different branches for different
PR destanation in GitHub Actions is not a trivial task and
will take time to develop.
But maybe current variant will be enough in major cases