### PR TITLE
fix(api): set "mobile" view mode for mobile browser access

### DIFF
--- a/apps/api/documents/api.js
+++ b/apps/api/documents/api.js
@@ -920,13 +920,11 @@
 
         var userAgent = navigator.userAgent.toLowerCase(),
             check = function(regex){ return regex.test(userAgent); },
-            isIE = !check(/opera/) && (check(/msie/) || check(/trident/) || check(/edge/)),
-            isChrome = !isIE && check(/\bchrome\b/),
-            isSafari_mobile = !isIE && !isChrome && check(/safari/) && (navigator.maxTouchPoints>0),
+            isMobileBrowser = check(/mobile|iphone|ipad|android|iemobile|opera m(obi|ini)/),
             path_type;
 
         path += app + "/";
-        path_type = (config.type === "mobile" || isSafari_mobile)
+        path_type = (config.type === "mobile" || isMobileBrowser)
                     ? "mobile" : (config.type === "embedded")
                     ? "embed" : (config.document && typeof config.document.fileType === 'string' && config.document.fileType.toLowerCase() === 'oform')
                     ? "forms" : "main";


### PR DESCRIPTION
Before, when accessing onlyoffice through a webview or on mobile browsers other than Safari, it would always open in Edit mode. This pull request should resolve the problem by ensuring that documents are consistently displayed in Mobile View mode when accessed on a mobile browser.