### PR TITLE
Improving Navigation across spreadsheets

### DIFF
--- a/apps/spreadsheeteditor/main/app/view/Statusbar.js
+++ b/apps/spreadsheeteditor/main/app/view/Statusbar.js
@@ -127,6 +127,7 @@ define([
                 this.sheetListMenu = new Common.UI.Menu({
                     style: 'margin-top:-3px;',
                     menuAlign: 'bl-tl',
+                    search: true,
                     maxHeight: 300
                 });
                 this.sheetListMenu.on('item:click', function(obj,item) {


### PR DESCRIPTION
Navigating through a large number of sheets can be difficult for large lists. 
Adding search: true to the dropdown (Common.UI.Menu) for the spreadsheet list significantly improves usability for me.

P.S.
It's worth considering making search: true the default behavior for Common.UI.Menu. In most dropdown menus across different operating systems, search functionality is enabled by default, it's a common user expectation for dropdowns.