### PR TITLE
[SSE mobile] prevent rbga to be converted to hsla

### DIFF
--- a/vendor/framework7-react/build/webpack.config.js
+++ b/vendor/framework7-react/build/webpack.config.js
@@ -190,6 +190,9 @@ const config = {
                 safe: true,
                 map: { inline: false },
             },
+            preset: ['default', {
+              colormin: false,
+            }],
         },
       }),
       new webpack.optimize.ModuleConcatenationPlugin(),


### PR DESCRIPTION
sdk supports colors only in rgba(r,g,...) format, not in hlsa(...) format
force plugin for optimizing css not to convert rgba to hlsa