### PR TITLE
fix bug 68900

### DIFF
--- a/apps/common/main/lib/component/MenuItem.js
+++ b/apps/common/main/lib/component/MenuItem.js
@@ -340,6 +340,7 @@ define([
 
             if (this.menu) {
                 if (e.target.id == this.id) {
+                    this._doHover(e);
                     return false;
                 }
 


### PR DESCRIPTION
fedora triggers focusout on click, thereby closing the submenu