### PR TITLE
fix bug 2907: prevent overlay during system shortcuts

### DIFF
--- a/apps/common/main/lib/controller/HintManager.js
+++ b/apps/common/main/lib/controller/HintManager.js
@@ -651,7 +651,15 @@ Common.UI.HintManager = new(function() {
             if (Common.Utils.InternalSettings.get(_appPrefix + "settings-show-alt-hints") && e.altKey && e.keyCode !== 115 && _isInternalEditorLoading) {
                 e.preventDefault();
             }
+
+
         });
+
+        // reset hint display state on focus loss, prevent showing hint during system shortcuts
+        $(window).on('blur', function() {
+            _needShow = false;
+        });
+        
     };
 
     var _getAlphabetLetters = function (lng) {


### PR DESCRIPTION
Fixes issue [#2907](https://github.com/ONLYOFFICE/DocumentServer/issues/2907) where keyboard hints incorrectly appear during system level shortcuts.