### PR TITLE
feat: SmartArt text pane UI for all editors

### DIFF
--- a/apps/common/main/lib/util/utils.js
+++ b/apps/common/main/lib/util/utils.js
@@ -118,7 +118,8 @@ define([], function () {
                 Pivot: 10,
                 Cell: 11,
                 Slicer: 12,
-                Form: 13
+                Form: 13,
+                SmartArtText: 14
             },
             importTextType = {
                 DRM: 0,

--- a/apps/common/main/lib/view/SmartArtTextPane.js
+++ b/apps/common/main/lib/view/SmartArtTextPane.js
@@ -1,0 +1,373 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2024
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * You can contact Ascensio System SIA at 20A-6 Ernesta Birznieka-Upish
+ * street, Riga, Latvia, EU, LV-1050.
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * Pursuant to Section 7(b) of the License you must retain the original Product
+ * logo when distributing the program. Pursuant to Section 7(e) we decline to
+ * grant you any rights under trademark law for use of our trademarks.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ */
+/**
+ *  SmartArtTextPane.js
+ *
+ *  Shared SmartArt text pane view for all editors.
+ *  Displays SmartArt data as a bulleted text outline
+ *  and allows inline editing with live sync to the SmartArt shapes.
+ *
+ */
+
+define([
+    'jquery',
+    'underscore',
+    'backbone',
+    'common/main/lib/component/Button'
+], function ($, _, Backbone) {
+    'use strict';
+
+    Common.Views = Common.Views || {};
+
+    Common.Views.SmartArtTextPane = Backbone.View.extend(_.extend({
+
+        template: _.template([
+            '<div class="smartart-text-pane">',
+                '<div class="smartart-text-pane-header">',
+                    '<span class="smartart-text-pane-title"><%= scope.txtTitle %></span>',
+                '</div>',
+                '<div class="smartart-text-pane-toolbar">',
+                    '<div id="smartart-btn-add-node" class="margin-right-4"></div>',
+                    '<div id="smartart-btn-remove-node" class="margin-right-4"></div>',
+                    '<div id="smartart-btn-promote" class="margin-right-4"></div>',
+                    '<div id="smartart-btn-demote" class="margin-right-4"></div>',
+                    '<div id="smartart-btn-move-up" class="margin-right-4"></div>',
+                    '<div id="smartart-btn-move-down"></div>',
+                '</div>',
+                '<div class="smartart-text-pane-content">',
+                    '<div class="smartart-text-list" tabindex="0"></div>',
+                '</div>',
+            '</div>'
+        ].join('')),
+
+        events: {},
+
+        options: {
+            alias: 'SmartArtTextPane'
+        },
+
+        initialize: function () {
+            this._initSettings = true;
+            this._noApply = true;
+            this._locked = false;
+            this._textPaneData = [];
+            this._activeNodeId = null;
+            this._suppressSync = false;
+
+            this.render();
+        },
+
+        render: function () {
+            var el = this.$el || $(this.el);
+            el.html(this.template({
+                scope: this
+            }));
+
+            this.btnAddNode = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-add-node'),
+                cls: 'btn-toolbar x-huge icon-top',
+                iconCls: 'toolbar__icon btn-zoomup',
+                caption: this.txtAddNode,
+                hint: this.txtAddNodeHint
+            });
+            this.btnAddNode.on('click', _.bind(this.onAddNode, this));
+
+            this.btnRemoveNode = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-remove-node'),
+                cls: 'btn-toolbar x-huge icon-top',
+                iconCls: 'toolbar__icon btn-zoomdown',
+                caption: this.txtRemoveNode,
+                hint: this.txtRemoveNodeHint
+            });
+            this.btnRemoveNode.on('click', _.bind(this.onRemoveNode, this));
+
+            this.btnPromote = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-promote'),
+                cls: 'btn-toolbar',
+                iconCls: 'toolbar__icon btn-decoffset',
+                hint: this.txtPromoteHint
+            });
+            this.btnPromote.on('click', _.bind(this.onPromote, this));
+
+            this.btnDemote = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-demote'),
+                cls: 'btn-toolbar',
+                iconCls: 'toolbar__icon btn-incoffset',
+                hint: this.txtDemoteHint
+            });
+            this.btnDemote.on('click', _.bind(this.onDemote, this));
+
+            this.btnMoveUp = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-move-up'),
+                cls: 'btn-toolbar',
+                iconCls: 'toolbar__icon btn-arrow-up',
+                hint: this.txtMoveUpHint
+            });
+            this.btnMoveUp.on('click', _.bind(this.onMoveUp, this));
+
+            this.btnMoveDown = new Common.UI.Button({
+                parentEl: el.find('#smartart-btn-move-down'),
+                cls: 'btn-toolbar',
+                iconCls: 'toolbar__icon btn-arrow-down',
+                hint: this.txtMoveDownHint
+            });
+            this.btnMoveDown.on('click', _.bind(this.onMoveDown, this));
+
+            this.textListEl = el.find('.smartart-text-list');
+            this.textListEl.on('keydown', _.bind(this.onKeyDown, this));
+        },
+
+        setApi: function (api) {
+            this.api = api;
+            if (this.api) {
+                this.api.asc_registerCallback('asc_onSmartArtDataChanged', _.bind(this.onSmartArtDataChanged, this));
+            }
+            return this;
+        },
+
+        setLocked: function (locked) {
+            this._locked = locked;
+            this.disableControls(locked);
+        },
+
+        disableControls: function (disabled) {
+            this.btnAddNode && this.btnAddNode.setDisabled(disabled);
+            this.btnRemoveNode && this.btnRemoveNode.setDisabled(disabled);
+            this.btnPromote && this.btnPromote.setDisabled(disabled);
+            this.btnDemote && this.btnDemote.setDisabled(disabled);
+            this.btnMoveUp && this.btnMoveUp.setDisabled(disabled);
+            this.btnMoveDown && this.btnMoveDown.setDisabled(disabled);
+        },
+
+        /**
+         * Called by the RightMenu controller when SmartArt selection changes.
+         * @param {Object} props - Shape/image properties from asc_onFocusObject
+         */
+        ChangeSettings: function (props) {
+            if (!this.api) return;
+
+            var data = this.api.asc_getSmartArtTextPaneData();
+            if (data) {
+                this._textPaneData = data;
+                this.renderTextList(data);
+            }
+        },
+
+        /**
+         * Called from the SDK when SmartArt data changes (e.g., after text edit in shape).
+         * @param {Array} data - Text pane data array
+         */
+        onSmartArtDataChanged: function (data) {
+            if (this._suppressSync) return;
+            if (data) {
+                this._textPaneData = data;
+                this.renderTextList(data);
+            }
+        },
+
+        /**
+         * Renders the bulleted text list from the SmartArt data model.
+         * @param {Array} data - Array of {id, text, level, pointType}
+         */
+        renderTextList: function (data) {
+            if (!this.textListEl) return;
+
+            var html = '';
+            var activeId = this._activeNodeId;
+
+            for (var i = 0; i < data.length; i++) {
+                var item = data[i];
+                var indent = item.level * 20;
+                var bulletChar = item.level === 0 ? '\u2022' : '\u25E6';
+                var isActive = (item.id === activeId) ? ' smartart-text-item-active' : '';
+                var displayText = item.text || '';
+
+                html += '<div class="smartart-text-item' + isActive + '" data-point-id="' + item.id + '" data-level="' + item.level + '" style="padding-left: ' + (10 + indent) + 'px;">';
+                html += '<span class="smartart-text-bullet">' + bulletChar + '</span>';
+                html += '<span class="smartart-text-input" contenteditable="true" data-point-id="' + item.id + '">' + _.escape(displayText) + '</span>';
+                html += '</div>';
+            }
+
+            if (data.length === 0) {
+                html = '<div class="smartart-text-empty">' + this.txtNoData + '</div>';
+            }
+
+            this.textListEl.html(html);
+
+            // Bind events to the input spans
+            var me = this;
+            this.textListEl.find('.smartart-text-input').on('input', function (e) {
+                me.onTextInput(e);
+            });
+            this.textListEl.find('.smartart-text-input').on('focus', function (e) {
+                var pointId = $(this).data('point-id');
+                me._activeNodeId = pointId;
+                me.textListEl.find('.smartart-text-item-active').removeClass('smartart-text-item-active');
+                $(this).closest('.smartart-text-item').addClass('smartart-text-item-active');
+            });
+        },
+
+        /**
+         * Handles text input in a text pane entry.
+         */
+        onTextInput: function (e) {
+            if (!this.api || this._locked) return;
+
+            var target = $(e.target);
+            var pointId = target.data('point-id');
+            var newText = target.text();
+
+            if (pointId) {
+                this._suppressSync = true;
+                this.api.asc_setSmartArtNodeText(String(pointId), newText);
+                this._suppressSync = false;
+            }
+        },
+
+        /**
+         * Handles keyboard shortcuts in the text list.
+         */
+        onKeyDown: function (e) {
+            if (!this.api || this._locked) return;
+
+            var activeEl = this.textListEl.find('.smartart-text-item-active');
+            var pointId = this._activeNodeId;
+
+            if (!pointId) return;
+
+            if (e.keyCode === 9 && !e.shiftKey) { // Tab = demote
+                e.preventDefault();
+                this.api.asc_demoteSmartArtNode(String(pointId));
+            } else if (e.keyCode === 9 && e.shiftKey) { // Shift+Tab = promote
+                e.preventDefault();
+                this.api.asc_promoteSmartArtNode(String(pointId));
+            } else if (e.keyCode === 13) { // Enter = add sibling
+                e.preventDefault();
+                this.onAddNode();
+            } else if (e.keyCode === 8) { // Backspace on empty = remove
+                var inputEl = activeEl.find('.smartart-text-input');
+                if (inputEl.length && inputEl.text().length === 0) {
+                    e.preventDefault();
+                    this.api.asc_removeSmartArtNode(String(pointId));
+                }
+            }
+        },
+
+        /**
+         * Add a sibling node after the active node.
+         */
+        onAddNode: function () {
+            if (!this.api || this._locked) return;
+
+            var pointId = this._activeNodeId;
+            // Find the parent of the active node from the data
+            var parentId = null;
+            var position = -1;
+
+            if (pointId && this._textPaneData) {
+                // Find the active item in the data to determine its parent
+                // Since we don't have direct parent info in the flat list,
+                // we use the API which will figure out the correct parent
+                var activeItem = null;
+                for (var i = 0; i < this._textPaneData.length; i++) {
+                    if (this._textPaneData[i].id === pointId) {
+                        activeItem = this._textPaneData[i];
+                        break;
+                    }
+                }
+            }
+
+            var newId = this.api.asc_addSmartArtNode({
+                parentPointId: null,
+                position: -1
+            });
+
+            if (newId) {
+                this._activeNodeId = newId;
+            }
+        },
+
+        /**
+         * Remove the active node.
+         */
+        onRemoveNode: function () {
+            if (!this.api || this._locked || !this._activeNodeId) return;
+            this.api.asc_removeSmartArtNode(String(this._activeNodeId));
+            this._activeNodeId = null;
+        },
+
+        /**
+         * Promote (decrease depth) of the active node.
+         */
+        onPromote: function () {
+            if (!this.api || this._locked || !this._activeNodeId) return;
+            this.api.asc_promoteSmartArtNode(String(this._activeNodeId));
+        },
+
+        /**
+         * Demote (increase depth) of the active node.
+         */
+        onDemote: function () {
+            if (!this.api || this._locked || !this._activeNodeId) return;
+            this.api.asc_demoteSmartArtNode(String(this._activeNodeId));
+        },
+
+        /**
+         * Move active node up among siblings.
+         */
+        onMoveUp: function () {
+            if (!this.api || this._locked || !this._activeNodeId) return;
+            this.api.asc_moveSmartArtNodeUp(String(this._activeNodeId));
+        },
+
+        /**
+         * Move active node down among siblings.
+         */
+        onMoveDown: function () {
+            if (!this.api || this._locked || !this._activeNodeId) return;
+            this.api.asc_moveSmartArtNodeDown(String(this._activeNodeId));
+        },
+
+        // Localization strings
+        txtTitle: 'Type your text here',
+        txtAddNode: 'Add',
+        txtRemoveNode: 'Remove',
+        txtAddNodeHint: 'Add Shape After',
+        txtRemoveNodeHint: 'Remove Shape',
+        txtPromoteHint: 'Promote',
+        txtDemoteHint: 'Demote',
+        txtMoveUpHint: 'Move Up',
+        txtMoveDownHint: 'Move Down',
+        txtNoData: 'No SmartArt data'
+
+    }, Common.Views.SmartArtTextPane || {}));
+});

--- a/apps/common/main/resources/less/common.less
+++ b/apps/common/main/resources/less/common.less
@@ -775,3 +775,90 @@ body {
     fill: var(--icon-success, #78b588);
     stroke: transparent;
 }
+
+// SmartArt Text Pane styles
+.smartart-text-pane {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.smartart-text-pane-header {
+    padding: 8px 0 8px 0;
+    border-bottom: @scaled-one-px-value solid @border-toolbar;
+
+    .smartart-text-pane-title {
+        font-weight: bold;
+        font-size: 12px;
+        color: @text-normal;
+    }
+}
+
+.smartart-text-pane-toolbar {
+    padding: 6px 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px;
+    border-bottom: @scaled-one-px-value solid @border-toolbar;
+}
+
+.smartart-text-pane-content {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-top: 4px;
+}
+
+.smartart-text-list {
+    outline: none;
+}
+
+.smartart-text-item {
+    display: flex;
+    align-items: flex-start;
+    padding: 3px 4px;
+    cursor: text;
+    border-radius: 2px;
+    min-height: 22px;
+
+    &:hover {
+        background-color: @highlight-button-hover;
+    }
+}
+
+.smartart-text-item-active {
+    background-color: @highlight-button-pressed !important;
+}
+
+.smartart-text-bullet {
+    flex-shrink: 0;
+    width: 14px;
+    color: @text-tertiary;
+    font-size: 12px;
+    line-height: 20px;
+    user-select: none;
+}
+
+.smartart-text-input {
+    flex: 1;
+    outline: none;
+    font-size: 11px;
+    line-height: 20px;
+    color: @text-normal;
+    word-break: break-word;
+    min-height: 20px;
+
+    &:empty::before {
+        content: attr(data-placeholder);
+        color: @text-tertiary;
+    }
+}
+
+.smartart-text-empty {
+    padding: 12px;
+    text-align: center;
+    color: @text-tertiary;
+    font-style: italic;
+    font-size: 11px;
+}

--- a/apps/documenteditor/main/app/controller/RightMenu.js
+++ b/apps/documenteditor/main/app/controller/RightMenu.js
@@ -100,6 +100,7 @@ define([
             this._settings[Common.Utils.documentSettingsType.MailMerge] = {panelId: "id-mail-merge-settings", panel: rightMenu.mergeSettings,    btn: rightMenu.btnMailMerge,   hidden: 1, props: {}, locked: false};
             this._settings[Common.Utils.documentSettingsType.Signature] = {panelId: "id-signature-settings",  panel: rightMenu.signatureSettings, btn: rightMenu.btnSignature,  hidden: 1, props: {}, locked: false};
             this._settings[Common.Utils.documentSettingsType.Form] = {panelId: "id-form-settings",  panel: rightMenu.formSettings, btn: rightMenu.btnForm,  hidden: 1, props: {}, locked: false};
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panelId: "id-smartart-text-settings", panel: rightMenu.smartArtTextSettings, btn: rightMenu.btnSmartArtText, hidden: 1, props: {}, locked: false};
         },
 
         setApi: function(api) {
@@ -218,6 +219,12 @@ define([
                             this._settings[Common.Utils.documentSettingsType.TextArt].props = value;
                             this._settings[Common.Utils.documentSettingsType.TextArt].hidden = 0;
                             this._settings[Common.Utils.documentSettingsType.TextArt].locked = value.get_Locked() || content_locked || isProtected;
+                        }
+                        // Show SmartArt text pane when a SmartArt or its internal shape is selected
+                        if (value.get_ShapeProperties().asc_getFromSmartArt() || isSmartArtInternal) {
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].props = value;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].hidden = 0;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].locked = value.get_Locked() || content_locked || isProtected;
                         }
                     }
                     control_lock = control_lock || value.get_Locked();

--- a/apps/documenteditor/main/app/template/RightMenu.template
+++ b/apps/documenteditor/main/app/template/RightMenu.template
@@ -24,7 +24,7 @@
         <button id="id-right-menu-mail-merge" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-mail-merge-settings"><i class="icon toolbar__icon btn-mailmerge">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-signature-settings"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
         <button id="id-right-menu-form" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-form-settings"><i class="icon toolbar__icon btn-field">&nbsp;</i></button>
-        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-smart-hierarchy">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/documenteditor/main/app/template/RightMenu.template
+++ b/apps/documenteditor/main/app/template/RightMenu.template
@@ -10,6 +10,7 @@
             <div id="id-textart-settings" class="settings-panel"></div>
             <div id="id-signature-settings" class="settings-panel"></div>
             <div id="id-form-settings" class="settings-panel"></div>
+            <div id="id-smartart-text-settings" class="settings-panel"></div>
         </div>
     </div>
     <div class="tool-menu-btns" role="menubar" aria-label="<%= scope.ariaRightMenu %>" aria-orientation="vertical">
@@ -23,6 +24,7 @@
         <button id="id-right-menu-mail-merge" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-mail-merge-settings"><i class="icon toolbar__icon btn-mailmerge">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-signature-settings"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
         <button id="id-right-menu-form" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-form-settings"><i class="icon toolbar__icon btn-field">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/documenteditor/main/app/view/RightMenu.js
+++ b/apps/documenteditor/main/app/view/RightMenu.js
@@ -261,7 +261,7 @@ define([
                 asctype: Common.Utils.documentSettingsType.SmartArtText,
                 enableToggle: true,
                 disabled: true,
-                iconCls: 'btn-ins-smartart',
+                iconCls: 'btn-smart-hierarchy',
                 toggleGroup: 'tabpanelbtnsGroup',
                 allowMouseEventsOnDisabled: true
             });

--- a/apps/documenteditor/main/app/view/RightMenu.js
+++ b/apps/documenteditor/main/app/view/RightMenu.js
@@ -59,6 +59,7 @@ define([
     'documenteditor/main/app/view/TextArtSettings',
     'documenteditor/main/app/view/SignatureSettings',
     'documenteditor/main/app/view/FormSettings',
+    'common/main/lib/view/SmartArtTextPane',
     'common/main/lib/component/Scroller',
     'common/main/lib/component/ListView',
 ], function (menuTemplate, $, _, Backbone) {
@@ -254,6 +255,21 @@ define([
             }
 
 
+            // SmartArt Text Pane
+            this.btnSmartArtText = new Common.UI.Button({
+                hint: this.txtSmartArtTextSettings,
+                asctype: Common.Utils.documentSettingsType.SmartArtText,
+                enableToggle: true,
+                disabled: true,
+                iconCls: 'btn-ins-smartart',
+                toggleGroup: 'tabpanelbtnsGroup',
+                allowMouseEventsOnDisabled: true
+            });
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panel: "id-smartart-text-settings", btn: this.btnSmartArtText};
+            this.btnSmartArtText.setElement($markup.findById('#id-right-menu-smartart-text'), false); this.btnSmartArtText.render().setVisible(true);
+            this.btnSmartArtText.on('click', this.onBtnMenuClick.bind(this));
+            this.smartArtTextSettings = new Common.Views.SmartArtTextPane({el: '#id-smartart-text-settings'});
+
             if (_.isUndefined(this.scroller)) {
                 this.scroller = new Common.UI.Scroller({
                     el: $(this.el).find('.right-panel > .content-box'),
@@ -289,6 +305,7 @@ define([
             if (this.mergeSettings) this.mergeSettings.setApi(api).on('editcomplete', _fire_editcomplete);
             if (this.signatureSettings) this.signatureSettings.setApi(api).on('editcomplete', _fire_editcomplete);
             if (this.formSettings) this.formSettings.setApi(api).on('editcomplete', _fire_editcomplete).on('updatescroller', _updateScroller);
+            if (this.smartArtTextSettings) this.smartArtTextSettings.setApi(api);
         },
 
         setMode: function(mode) {
@@ -402,7 +419,7 @@ define([
 
         setButtons: function () {
             var allButtons = [this.btnText, this.btnTable, this.btnImage, this.btnShape, this.btnChart, this.btnTextArt,
-                    this.btnMailMerge, this.btnSignature, this.btnForm];
+                    this.btnMailMerge, this.btnSignature, this.btnForm, this.btnSmartArtText];
             Common.UI.SideMenu.prototype.setButtons.apply(this, [allButtons]);
         },
 
@@ -434,6 +451,7 @@ define([
         txtMailMergeSettings:       'Mail Merge Settings',
         txtSignatureSettings:       'Signature Settings',
         txtFormSettings:            'Form Settings',
+        txtSmartArtTextSettings:    'SmartArt Text',
         ariaRightMenu:              'Right menu'
     }, DE.Views.RightMenu || {}));
 });

--- a/apps/presentationeditor/main/app/controller/RightMenu.js
+++ b/apps/presentationeditor/main/app/controller/RightMenu.js
@@ -92,6 +92,7 @@ define([
             this._settings[Common.Utils.documentSettingsType.TextArt] =   {panelId: "id-textart-settings",    panel: rightMenu.textartSettings,  btn: rightMenu.btnTextArt,     hidden: 1, locked: false};
             this._settings[Common.Utils.documentSettingsType.Chart] = {panelId: "id-chart-settings",          panel: rightMenu.chartSettings,    btn: rightMenu.btnChart,       hidden: 1, locked: false};
             this._settings[Common.Utils.documentSettingsType.Signature] = {panelId: "id-signature-settings",  panel: rightMenu.signatureSettings, btn: rightMenu.btnSignature,  hidden: 1, props: {}, locked: false};
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panelId: "id-smartart-text-settings", panel: rightMenu.smartArtTextSettings, btn: rightMenu.btnSmartArtText, hidden: 1, props: {}, locked: false};
         },
 
         setApi: function(api) {
@@ -169,6 +170,12 @@ define([
                             this._settings[Common.Utils.documentSettingsType.TextArt].props = value;
                             this._settings[Common.Utils.documentSettingsType.TextArt].hidden = 0;
                             this._settings[Common.Utils.documentSettingsType.TextArt].locked = value.get_Locked();
+                        }
+                        // Show SmartArt text pane when a SmartArt shape is selected
+                        if (value.asc_getFromSmartArt && (value.asc_getFromSmartArt() || value.asc_getFromSmartArtInternal && value.asc_getFromSmartArtInternal())) {
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].props = value;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].hidden = 0;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].locked = value.get_Locked();
                         }
                     }
                 }

--- a/apps/presentationeditor/main/app/template/RightMenu.template
+++ b/apps/presentationeditor/main/app/template/RightMenu.template
@@ -9,6 +9,7 @@
             <div id="id-chart-settings" class="settings-panel"></div>
             <div id="id-textart-settings" class="settings-panel"></div>
             <div id="id-signature-settings" class="settings-panel"></div>
+            <div id="id-smartart-text-settings" class="settings-panel"></div>
         </div>
     </div>
     <div class="tool-menu-btns" role="menubar" aria-label="<%= scope.ariaRightMenu %>" aria-orientation="vertical">
@@ -21,6 +22,7 @@
         <button id="id-right-menu-chart" class="btn btn-category arrow-left" content-target="id-chart-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-chart">&nbsp;</i></button>
         <button id="id-right-menu-textart" class="btn btn-category arrow-left" content-target="id-textart-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-textart">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" content-target="id-signature-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" content-target="id-smartart-text-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/presentationeditor/main/app/template/RightMenu.template
+++ b/apps/presentationeditor/main/app/template/RightMenu.template
@@ -22,7 +22,7 @@
         <button id="id-right-menu-chart" class="btn btn-category arrow-left" content-target="id-chart-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-chart">&nbsp;</i></button>
         <button id="id-right-menu-textart" class="btn btn-category arrow-left" content-target="id-textart-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-textart">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" content-target="id-signature-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
-        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" content-target="id-smartart-text-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" content-target="id-smartart-text-settings" data-hint="0" data-hint-direction="left" data-hint-offset="big"><i class="icon toolbar__icon btn-smart-hierarchy">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/presentationeditor/main/app/view/RightMenu.js
+++ b/apps/presentationeditor/main/app/view/RightMenu.js
@@ -228,7 +228,7 @@ define([
                 asctype: Common.Utils.documentSettingsType.SmartArtText,
                 enableToggle: true,
                 disabled: true,
-                iconCls: 'btn-ins-smartart',
+                iconCls: 'btn-smart-hierarchy',
                 toggleGroup: 'tabpanelbtnsGroup',
                 allowMouseEventsOnDisabled: true
             });

--- a/apps/presentationeditor/main/app/view/RightMenu.js
+++ b/apps/presentationeditor/main/app/view/RightMenu.js
@@ -57,6 +57,7 @@ define([
     'presentationeditor/main/app/view/SlideSettings',
     'presentationeditor/main/app/view/TextArtSettings',
     'presentationeditor/main/app/view/SignatureSettings',
+    'common/main/lib/view/SmartArtTextPane',
     'common/main/lib/component/Scroller',
     'common/main/lib/component/ListView',
 ], function (menuTemplate, $, _, Backbone) {
@@ -148,6 +149,7 @@ define([
             this._settings[Common.Utils.documentSettingsType.Shape]       = {panel: "id-shape-settings",      btn: this.btnShape};
             this._settings[Common.Utils.documentSettingsType.Chart]       = {panel: "id-chart-settings",      btn: this.btnChart};
             this._settings[Common.Utils.documentSettingsType.TextArt]     = {panel: "id-textart-settings",    btn: this.btnTextArt};
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panel: "id-smartart-text-settings", btn: undefined};
 
             return this;
         },
@@ -220,6 +222,21 @@ define([
                 this.signatureSettings = new PE.Views.SignatureSettings();
             }
 
+            // SmartArt Text Pane
+            this.btnSmartArtText = new Common.UI.Button({
+                hint: this.txtSmartArtTextSettings,
+                asctype: Common.Utils.documentSettingsType.SmartArtText,
+                enableToggle: true,
+                disabled: true,
+                iconCls: 'btn-ins-smartart',
+                toggleGroup: 'tabpanelbtnsGroup',
+                allowMouseEventsOnDisabled: true
+            });
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panel: "id-smartart-text-settings", btn: this.btnSmartArtText};
+            this.btnSmartArtText.setElement($('#id-right-menu-smartart-text'), false); this.btnSmartArtText.render().setVisible(true);
+            this.btnSmartArtText.on('click', _.bind(this.onBtnMenuClick, this));
+            this.smartArtTextSettings = new Common.Views.SmartArtTextPane({el: '#id-smartart-text-settings'});
+
             if (_.isUndefined(this.scroller)) {
                 this.scroller = new Common.UI.Scroller({
                     el: $(this.el).find('.right-panel > .content-box'),
@@ -252,6 +269,7 @@ define([
             this.shapeSettings.setApi(api).on('editcomplete', _.bind( fire, this)).on('eyedropper', _.bind(_isEyedropperStart, this)).on('updatescroller', _updateScroller);
             this.textartSettings.setApi(api).on('editcomplete', _.bind( fire, this)).on('eyedropper', _.bind(_isEyedropperStart, this)).on('updatescroller', _updateScroller);
             if (this.signatureSettings) this.signatureSettings.setApi(api).on('editcomplete', _.bind( fire, this));
+            if (this.smartArtTextSettings) this.smartArtTextSettings.setApi(api);
         },
 
         setMode: function(mode) {
@@ -358,7 +376,7 @@ define([
         },
 
         setButtons: function () {
-            var allButtons = [this.btnSlide, this.btnShape, this.btnImage, this.btnText, this.btnTable, this.btnChart, this.btnTextArt, this.btnSignature];
+            var allButtons = [this.btnSlide, this.btnShape, this.btnImage, this.btnText, this.btnTable, this.btnChart, this.btnTextArt, this.btnSignature, this.btnSmartArtText];
             Common.UI.SideMenu.prototype.setButtons.apply(this, [allButtons]);
         },
 
@@ -388,6 +406,7 @@ define([
         txtSlideSettings:           'Slide Settings',
         txtChartSettings:           'Chart Settings',
         txtSignatureSettings:       'Signature Settings',
+        txtSmartArtTextSettings:    'SmartArt Text',
         ariaRightMenu:              'Right menu'
     }, PE.Views.RightMenu || {}));
 });

--- a/apps/spreadsheeteditor/main/app/controller/RightMenu.js
+++ b/apps/spreadsheeteditor/main/app/controller/RightMenu.js
@@ -103,6 +103,7 @@ define([
             this._settings[Common.Utils.documentSettingsType.Signature] = {panelId: "id-signature-settings",  panel: rightMenu.signatureSettings, btn: rightMenu.btnSignature,  hidden: 1, props: {}, locked: false};
             this._settings[Common.Utils.documentSettingsType.Cell] =      {panelId: "id-cell-settings",       panel: rightMenu.cellSettings,     btn: rightMenu.btnCell,        hidden: 1, locked: false};
             this._settings[Common.Utils.documentSettingsType.Slicer] =    {panelId: "id-slicer-settings",     panel: rightMenu.slicerSettings,   btn: rightMenu.btnSlicer,      hidden: 1, locked: false};
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panelId: "id-smartart-text-settings", panel: rightMenu.smartArtTextSettings, btn: rightMenu.btnSmartArtText, hidden: 1, props: {}, locked: false};
         },
 
         setApi: function(api) {
@@ -205,6 +206,13 @@ define([
                             this._settings[Common.Utils.documentSettingsType.TextArt].props = value;
                             this._settings[Common.Utils.documentSettingsType.TextArt].hidden = 0;
                             this._settings[Common.Utils.documentSettingsType.TextArt].locked = value.asc_getLocked() || this._state.wsProps['Objects'] && value.asc_getProtectionLockText();
+                        }
+                        // Show SmartArt text pane when a SmartArt shape is selected
+                        var shapeProps = value.asc_getShapeProperties();
+                        if (shapeProps && ((shapeProps.asc_getFromSmartArt && shapeProps.asc_getFromSmartArt()) || (shapeProps.asc_getFromSmartArtInternal && shapeProps.asc_getFromSmartArtInternal()))) {
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].props = value;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].hidden = 0;
+                            this._settings[Common.Utils.documentSettingsType.SmartArtText].locked = value.asc_getLocked() || this._state.wsProps['Objects'] && value.asc_getProtectionLocked();
                         }
                     } else if (value.asc_getSlicerProperties() !== null) {
                         settingsType = Common.Utils.documentSettingsType.Slicer;

--- a/apps/spreadsheeteditor/main/app/template/RightMenu.template
+++ b/apps/spreadsheeteditor/main/app/template/RightMenu.template
@@ -24,7 +24,7 @@
         <button id="id-right-menu-slicer" class="btn btn-category arrow-left" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-slicer-settings"><i class="icon toolbar__icon btn-slicer">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-signature-settings"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
         <button id="id-right-menu-pivot" class="btn btn-category arrow-left" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-pivot-settings"><i class="icon toolbar__icon btn-pivot-sum">&nbsp;</i></button>
-        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-smart-hierarchy">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/spreadsheeteditor/main/app/template/RightMenu.template
+++ b/apps/spreadsheeteditor/main/app/template/RightMenu.template
@@ -10,6 +10,7 @@
             <div id="id-signature-settings" class="settings-panel"></div>
             <div id="id-cell-settings" class="settings-panel"></div>
             <div id="id-slicer-settings" class="settings-panel"></div>
+            <div id="id-smartart-text-settings" class="settings-panel"></div>
         </div>
     </div>
     <div class="tool-menu-btns" role="menubar" aria-label="<%= scope.ariaRightMenu %>" aria-orientation="vertical">
@@ -23,6 +24,7 @@
         <button id="id-right-menu-slicer" class="btn btn-category arrow-left" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-slicer-settings"><i class="icon toolbar__icon btn-slicer">&nbsp;</i></button>
         <button id="id-right-menu-signature" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-signature-settings"><i class="icon toolbar__icon btn-menu-signature">&nbsp;</i></button>
         <button id="id-right-menu-pivot" class="btn btn-category arrow-left" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-pivot-settings"><i class="icon toolbar__icon btn-pivot-sum">&nbsp;</i></button>
+        <button id="id-right-menu-smartart-text" class="btn btn-category arrow-left hidden" data-hint="0" data-hint-direction="left" data-hint-offset="big" content-target="id-smartart-text-settings"><i class="icon toolbar__icon btn-ins-smartart">&nbsp;</i></button>
         <div id="slot-right-menu-more"></div>
     </div>
 </div>

--- a/apps/spreadsheeteditor/main/app/view/RightMenu.js
+++ b/apps/spreadsheeteditor/main/app/view/RightMenu.js
@@ -244,7 +244,7 @@ define([
                 asctype: Common.Utils.documentSettingsType.SmartArtText,
                 enableToggle: true,
                 disabled: true,
-                iconCls: 'btn-ins-smartart',
+                iconCls: 'btn-smart-hierarchy',
                 toggleGroup: 'tabpanelbtnsGroup',
                 allowMouseEventsOnDisabled: true
             });

--- a/apps/spreadsheeteditor/main/app/view/RightMenu.js
+++ b/apps/spreadsheeteditor/main/app/view/RightMenu.js
@@ -58,6 +58,7 @@ define([
     'spreadsheeteditor/main/app/view/SignatureSettings',
     'spreadsheeteditor/main/app/view/CellSettings',
     'spreadsheeteditor/main/app/view/SlicerSettings',
+    'common/main/lib/view/SmartArtTextPane',
     'common/main/lib/component/Scroller',
     'common/main/lib/component/ListView',
 ], function (menuTemplate, $, _, Backbone) {
@@ -237,6 +238,21 @@ define([
                 this.signatureSettings = new SSE.Views.SignatureSettings();
             }
 
+            // SmartArt Text Pane
+            this.btnSmartArtText = new Common.UI.Button({
+                hint: this.txtSmartArtTextSettings,
+                asctype: Common.Utils.documentSettingsType.SmartArtText,
+                enableToggle: true,
+                disabled: true,
+                iconCls: 'btn-ins-smartart',
+                toggleGroup: 'tabpanelbtnsGroup',
+                allowMouseEventsOnDisabled: true
+            });
+            this._settings[Common.Utils.documentSettingsType.SmartArtText] = {panel: "id-smartart-text-settings", btn: this.btnSmartArtText};
+            this.btnSmartArtText.setElement($('#id-right-menu-smartart-text'), false); this.btnSmartArtText.render().setVisible(true);
+            this.btnSmartArtText.on('click', _.bind(this.onBtnMenuClick, this));
+            this.smartArtTextSettings = new Common.Views.SmartArtTextPane({el: '#id-smartart-text-settings'});
+
             if (_.isUndefined(this.scroller)) {
                 this.scroller = new Common.UI.Scroller({
                     el: $(this.el).find('.right-panel > .content-box'),
@@ -269,6 +285,7 @@ define([
             this.cellSettings.setApi(api).on('eyedropper', _.bind(_isEyedropperStart, this));
             this.slicerSettings.setApi(api);
             if (this.signatureSettings) this.signatureSettings.setApi(api);
+            if (this.smartArtTextSettings) this.smartArtTextSettings.setApi(api);
             return this;
         },
 
@@ -370,7 +387,7 @@ define([
         },
 
         setButtons: function () {
-            var allButtons = [this.btnCell, this.btnShape, this.btnImage, this.btnChart, this.btnText, this.btnTextArt, this.btnSlicer, this.btnSignature, this.btnPivot];
+            var allButtons = [this.btnCell, this.btnShape, this.btnImage, this.btnChart, this.btnText, this.btnTextArt, this.btnSlicer, this.btnSignature, this.btnPivot, this.btnSmartArtText];
             Common.UI.SideMenu.prototype.setButtons.apply(this, [allButtons]);
         },
 
@@ -402,6 +419,7 @@ define([
         txtSignatureSettings:       'Signature Settings',
         txtCellSettings:            'Cell Settings',
         txtSlicerSettings:          'Slicer Settings',
+        txtSmartArtTextSettings:    'SmartArt Text',
         ariaRightMenu:              'Right menu'
     }, SSE.Views.RightMenu || {}));
 });

--- a/build/documenteditor.json
+++ b/build/documenteditor.json
@@ -1,7 +1,7 @@
 {
     "name": "documenteditor",
     "version": "4.3.0",
-    "build": 1150,
+    "build": 1151,
     "homepage": "http://www.onlyoffice.com",
     "private": true,
     "main": {
@@ -94,7 +94,7 @@
                 }
             },
             "postload": {
-                "options":{
+                "options": {
                     "baseUrl": "../apps/",
                     "optimize": "none",
                     "name": "../apps/documenteditor/main/app_pack.js",

--- a/build/presentationeditor.json
+++ b/build/presentationeditor.json
@@ -1,7 +1,7 @@
 {
     "name": "presentationeditor",
     "version": "4.3.0",
-    "build": 790,
+    "build": 791,
     "homepage": "http://www.onlyoffice.com",
     "private": true,
     "main": {

--- a/build/spreadsheeteditor.json
+++ b/build/spreadsheeteditor.json
@@ -1,7 +1,7 @@
 {
     "name": "spreadsheeteditor",
     "version": "4.3.0",
-    "build": 903,
+    "build": 904,
     "homepage": "http://www.onlyoffice.com",
     "private": true,
     "main": {
@@ -94,7 +94,7 @@
                 }
             },
             "postload": {
-                "options":{
+                "options": {
                     "baseUrl": "../apps/",
                     "optimize": "none",
                     "name": "../apps/spreadsheeteditor/main/app_pack.js",


### PR DESCRIPTION
## Summary

- Add shared SmartArt text pane component with inline text editing, node operations, and keyboard shortcuts
- Integrate text pane into Document Editor, Presentation Editor, and Spreadsheet Editor right sidebars
- Add CSS styling for the text pane following existing panel conventions

## Changes

### Shared Components
- **`apps/common/main/lib/view/SmartArtTextPane.js`** (NEW) - Backbone view that displays SmartArt data as a bulleted text outline with contenteditable spans, toolbar buttons (Add/Remove/Promote/Demote/Move), keyboard shortcuts (Tab/Shift+Tab/Enter/Backspace), and bidirectional sync via `asc_onSmartArtDataChanged` callback
- **`apps/common/main/lib/util/utils.js`** - Add `SmartArtText: 14` to `documentSettingsType` enum
- **`apps/common/main/resources/less/common.less`** - Add SmartArt text pane styles

### Document Editor
- Add panel div and button to `RightMenu.template`
- Register panel in `RightMenu.js` view (button, settings entry, setApi)
- Add SmartArt detection in `RightMenu.js` controller (onFocusObject) to auto-show panel

### Presentation Editor
- Same pattern as Document Editor applied to `presentationeditor/` files

### Spreadsheet Editor
- Same pattern as Document Editor applied to `spreadsheeteditor/` files

## Related PR
SDK core changes: https://github.com/ONLYOFFICE/sdkjs/pull/4876