### PR TITLE
Allow iframe location to be in the local network

### DIFF
--- a/apps/api/documents/api.js
+++ b/apps/api/documents/api.js
@@ -1263,7 +1263,7 @@
         iframe.allowFullscreen = true;
         iframe.setAttribute("allowfullscreen",""); // for IE11
         iframe.setAttribute("onmousewheel",""); // for Safari on Mac
-        iframe.setAttribute("allow", "autoplay; camera; microphone; display-capture; clipboard-write;");
+        iframe.setAttribute("allow", "autoplay; camera; microphone; display-capture; clipboard-write; local-network-access;");
 
 		if (config.type == "mobile")
 		{


### PR DESCRIPTION
The additional allow attribute value 'local-network-access' is required if the document server / editor runs in the local network.