### PR TITLE
refactor(apps): make analytics dependency optional

### DIFF
--- a/apps/documenteditor/forms/app.js
+++ b/apps/documenteditor/forms/app.js
@@ -115,10 +115,11 @@ require([
     'underscore',
     'core',
     'api',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/documenteditor/forms/app_dev.js
+++ b/apps/documenteditor/forms/app_dev.js
@@ -103,11 +103,12 @@ require([
     'underscore',
     'core',
     'api',
-    'analytics',
     'gateway',
     'locale',
     'socketio',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/documenteditor/main/app.js
+++ b/apps/documenteditor/main/app.js
@@ -119,10 +119,11 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/documenteditor/main/app_dev.js
+++ b/apps/documenteditor/main/app_dev.js
@@ -108,11 +108,12 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale',
     'socketio',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/pdfeditor/main/app.js
+++ b/apps/pdfeditor/main/app.js
@@ -119,10 +119,11 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/pdfeditor/main/app_dev.js
+++ b/apps/pdfeditor/main/app_dev.js
@@ -108,11 +108,12 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale',
     'socketio',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/presentationeditor/main/app.js
+++ b/apps/presentationeditor/main/app.js
@@ -118,10 +118,11 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/presentationeditor/main/app_dev.js
+++ b/apps/presentationeditor/main/app_dev.js
@@ -107,12 +107,13 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale',
     'socketio',
     'xregexp',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/spreadsheeteditor/main/app.js
+++ b/apps/spreadsheeteditor/main/app.js
@@ -118,10 +118,11 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/spreadsheeteditor/main/app_dev.js
+++ b/apps/spreadsheeteditor/main/app_dev.js
@@ -107,11 +107,12 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale',
 	'socketio',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/visioeditor/main/app.js
+++ b/apps/visioeditor/main/app.js
@@ -119,10 +119,11 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale'
 ], function (Sdk, Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();

--- a/apps/visioeditor/main/app_dev.js
+++ b/apps/visioeditor/main/app_dev.js
@@ -108,11 +108,12 @@ require([
     'backbone',
     'underscore',
     'core',
-    'analytics',
     'gateway',
     'locale',
     'socketio',
 ], function (Backbone, _, Core) {
+    require(['analytics'], function() {}, function() {});
+
     if (Backbone.History && Backbone.History.started)
         return;
     Backbone.history.start();


### PR DESCRIPTION
Remove `analytics` from the main RequireJS dependency list in editor apps and load it separately as an optional module.

Previously, if `common/Analytics.js` was unavailable or blocked by browser privacy extensions/ad blockers, the main editor bootstrap failed and the document stayed stuck on the loading screen.

Analytics is not required for editor functionality, so the editor should continue to initialize even when the analytics module cannot be loaded.

Affected editors:
- documenteditor
- pdfeditor
- presentationeditor
- spreadsheeteditor
- visioeditor