### PR TITLE
Apply preset custom uiTheme colors on first load

### DIFF
--- a/apps/common/main/lib/controller/Themes.js
+++ b/apps/common/main/lib/controller/Themes.js
@@ -222,7 +222,11 @@ define([
 
         var create_colors_css = function (id, colors) {
             if ( !!colors && !!id ) {
-                var _css_array = [':root .', id, '{'];
+                // Repeat the theme class (`:root .id.id`) to raise specificity above
+                // the base per-type rules (`:root .theme-type-dark { ... }`), which a
+                // single `:root .id` only ties — so a dark/light custom theme's tokens
+                // (e.g. --background-toolbar) would otherwise lose to the base value.
+                var _css_array = [':root .', id, '.', id, '{'];
                 for (var c in colors) {
                     if (c==='highlight-toolbar-tab-underline') {
                         _css_array.push('--', c + '-document', ':', colors[c], ';');
@@ -290,6 +294,20 @@ define([
             let theme_id = window.uitheme.id;
             if ( themes_map[theme_id] ) {
                 if ( themes_map[theme_id].source != 'static') {
+                    // A custom theme preset via customization.uiTheme arrives here as
+                    // an id only; its colors live in themes.json and are loaded async.
+                    // apply_theme() (runtime selection) is what normally turns those
+                    // colors into CSS vars, so on a fresh load with a preset theme the
+                    // vars are never written and the editor falls back to the base
+                    // dark/light theme. Write them here, once, the first time the
+                    // launched theme is resolved.
+                    let t = themes_map[theme_id];
+                    if ( t.src && t.src.colors ) {
+                        write_theme_css(t.src.id, create_colors_css(t.src.id, t.src.colors));
+                        normalize_theme_icons(t);
+                        delete t.src; // mirror apply_theme: writing once consumes src
+                    }
+
                     const m = document.body.className.match('theme-type-' + themes_map[theme_id].type);
                     if ( !m )
                         document.body.classList.add('theme-type-' + themes_map[theme_id].type);


### PR DESCRIPTION
### What problem does this solve?

A custom theme passed via `customization.uiTheme` doesn't apply its colors on a fresh load. The editor renders the base dark/light theme instead, and the custom colors only appear once you re-pick the theme from the Interface Theme menu.

Root cause: the theme arrives as an id only, and its `colors` (loaded async from `themes.json`) are turned into CSS vars by `apply_theme`, which only runs on **runtime selection**. On preset load, `check_launched_custom_theme` sets the body class but never writes the colors.

### How does this solve it?

Two changes in `apps/common/main/lib/controller/Themes.js`:

1. `check_launched_custom_theme` now writes the launched theme's colors once, the first time it resolves, mirroring what `apply_theme` does. So a preset theme behaves like a selected one.
2. `create_colors_css` emits a doubled-class selector (`:root .id.id`). A single `:root .id` only ties the base `:root .theme-type-dark { ... }` rules and loses on cascade order, so a dark/light custom theme's tokens (e.g. `--background-toolbar`) silently fell back to the base value. This also fixes runtime selection of dark custom themes, not just preset load.

### How do I test this?

Tested locally against `onlyoffice/documentserver-de` 9.4.0 with a custom theme preset via `uiTheme`. Without the change the toolbar loads in the base theme; with it the custom colors apply on first paint. Reproduced the base-theme fallback as a control, then confirmed the fix renders the custom colors.
