### PR TITLE
[main] fix keytip shortcut persistence between ribbon tab switches

### DIFF
--- a/apps/common/main/lib/controller/HintManager.js
+++ b/apps/common/main/lib/controller/HintManager.js
@@ -313,7 +313,28 @@ Common.UI.HintManager = new(function() {
         var visibleItemsWithStaticTitle = itemsWithStaticTitle.filter(function (item) {
             return $(item).is(':visible');
         });
-        if (visibleItems.length === visibleItemsWithTitle.length) { // all buttons have data-hint-title-lang
+        // Remove dynamically assigned data-hint-title-lang for items without a static data-hint-title
+        // to force recalculation when the number of visible items changes between tabs.
+        // This prevents stale keytips on shared (static panel) buttons like the format painter.
+        visibleItems.forEach(function (item) {
+            var el = $(item);
+            if (!el.attr('data-hint-title') && el.attr('data-hint-title-lang')) {
+                el.removeAttr('data-hint-title-lang');
+            }
+        });
+        // Recount items with title after cleanup
+        if (_.isArray(_currentSection)) {
+            itemsWithTitle = [];
+            _currentSection.forEach(function (section) {
+                itemsWithTitle = itemsWithTitle.concat($(section).find('[data-hint-title-lang][data-hint=' + (_currentLevel) + ']').toArray());
+            });
+        } else {
+            itemsWithTitle = $(_currentSection).find('[data-hint-title-lang][data-hint=' + (_currentLevel) + ']').toArray();
+        }
+        visibleItemsWithTitle = itemsWithTitle.filter(function (item) {
+            return $(item).is(':visible');
+        });
+        if (visibleItems.length === visibleItemsWithTitle.length) { // all buttons have data-hint-title-lang (from static data-hint-title)
             visibleItems.forEach(function (item) {
                 _currentControls.push($(item));
             });


### PR DESCRIPTION
When switching between ribbon tabs using Alt shortcuts (e.g. Alt+N then Alt+H), dynamically assigned data-hint-title-lang attributes from the previous tab visit persisted. This caused HintManager to incorrectly assume all visible items already had keytip titles assigned and skip reassignment, resulting in shortened single-letter shortcuts (such as 'A' instead of 'AA' for the format painter).

This commit removes dynamically assigned data-hint-title-lang attributes when recounting items before the length check, ensuring correct multi-letter keytips are generated when switching tabs.